### PR TITLE
README: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In order to build, execute the following command:
 Once build just set the `RHINODO_HOME` variable to where the `uberjar` can be found. Usually, that would be you `target` folder.
 
 ```sh
-export RHINODO='path/to/rhinodo/target'
+export RHINODO_HOME='path/to/rhinodo/target'
 ```
 
 And after that just run:


### PR DESCRIPTION
`RHINODO_HOME` in mentioned in the prose, but then `RHINODO` is the variable used in the command-line example.  I believe it was meant to be `RHINODO_HOME`. :smile: 
